### PR TITLE
Add date time comparison

### DIFF
--- a/src/main/java/jarvis/command/EventCommand.java
+++ b/src/main/java/jarvis/command/EventCommand.java
@@ -1,5 +1,7 @@
 package jarvis.command;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
 import jarvis.converter.DateConverter;
@@ -52,6 +54,8 @@ public class EventCommand {
             this.verifyDateTimeDescription(start);
             this.verifyDateTimeDescription(end);
             this.verifyDateTimeCode(start[0], end[0]);
+            this.verifyTimeline(new DateConverter(start[1]).getDate(), new TimeConverter(start[2]).getTime(),
+                    new DateConverter(end[1]).getDate(), new TimeConverter(end[2]).getTime());
 
             String startDate = new DateConverter(start[1]).convert();
             String startTime = new TimeConverter(start[2]).convert();
@@ -67,6 +71,23 @@ public class EventCommand {
             return this.error.getMessage("invalid datetime format");
         } catch (Exception e) {
             return e.getMessage();
+        }
+    }
+
+    /**
+     * Verifies that the event's end date/time is not before its start date/time.
+     *
+     * @param startDate the start date of the event.
+     * @param startTime the start time of the event.
+     * @param endDate the end date of the event.
+     * @param endTime the end time of the event.
+     * @throws Exception if the end date/time is before the start date/time.
+     */
+    private void verifyTimeline(LocalDate startDate, LocalTime startTime,
+                                LocalDate endDate, LocalTime endTime) throws Exception {
+        if (endDate.isBefore(startDate) ||
+                (endDate.isEqual(startDate) && endTime.isBefore(startTime))) {
+            throw new Exception(this.error.getMessage("invalid event timeline"));
         }
     }
 

--- a/src/main/java/jarvis/converter/DateConverter.java
+++ b/src/main/java/jarvis/converter/DateConverter.java
@@ -22,6 +22,15 @@ public class DateConverter {
     }
 
     /**
+     * Returns the LocalDate object.
+     *
+     * @return the LocalDate object
+     */
+    public LocalDate getDate() {
+        return this.date;
+    }
+
+    /**
      * Returns the date in the "MMM d yyyy" format.
      *
      * @return the date string in the "MMM d yyyy" format

--- a/src/main/java/jarvis/converter/TimeConverter.java
+++ b/src/main/java/jarvis/converter/TimeConverter.java
@@ -15,9 +15,17 @@ public class TimeConverter {
     /** Time of the day. */
     private final LocalTime time;
 
-
     public TimeConverter(String time) {
         this.time = LocalTime.parse(time, FORMAT);
+    }
+
+    /**
+     * Returns the LocalTime object.
+     *
+     * @return the LocalTime object
+     */
+    public LocalTime getTime() {
+        return this.time;
     }
 
     /**

--- a/src/main/java/jarvis/ui/ErrorMessage.java
+++ b/src/main/java/jarvis/ui/ErrorMessage.java
@@ -32,7 +32,15 @@ public class ErrorMessage {
             (e.g., 2019-10-15 1800)
             Protocol requires precision.
             """;
-    /** Message for an incorrect event date/time format. */
+    /** Message for an incorrect deadline date/time code. */
+    private static final String INVALID_DEADLINE_DATETIME_CODE = """
+            \
+            Sir, please format your deadline description with starting code as:
+                /by yyyy-MM-dd HHmm
+            (e.g., /by 2024-09-30 2359)
+            Protocol requires precision.
+            """;
+    /** Message for an incorrect event date/time code. */
     private static final String INVALID_EVENT_DATETIME_CODE = """
             \
             Sir, please format your event description with starting code as:
@@ -40,13 +48,13 @@ public class ErrorMessage {
             (e.g., /from 2025-10-01 1400/to 2025-10-01 1500)
             Protocol requires precision.
             """;
-    /** Message for an incorrect event date/time format. */
-    private static final String INVALID_DEADLINE_DATETIME_CODE = """
+    /** Message for when an event's start date is after its end date. */
+    private static final String INVALID_EVENT_TIMELINE = """
             \
-            Sir, please format your deadline description with starting code as:
-                /by yyyy-MM-dd HHmm
-            (e.g., /by 2024-09-30 2359)
-            Protocol requires precision.
+            Sir, the event's start date occurs after its end date.
+            Please ensure chronological consistency by setting:
+                [start] ≤ [end]
+            Protocol cannot proceed with inverted timelines.
             """;
     /** Message for when the tag description is missing. */
     private static final String MISSING_TAG_DESCRIPTION = """
@@ -96,8 +104,9 @@ public class ErrorMessage {
             case "invalid tag index" -> INVALID_TAG_INDEX;
             case "invalid index format" -> INVALID_INDEX_FORMAT;
             case "invalid datetime format" -> INVALID_DATETIME_FORMAT;
-            case "invalid event datetime code" -> INVALID_EVENT_DATETIME_CODE;
             case "invalid deadline datetime code" -> INVALID_DEADLINE_DATETIME_CODE;
+            case "invalid event datetime code" -> INVALID_EVENT_DATETIME_CODE;
+            case "invalid event timeline" -> INVALID_EVENT_TIMELINE;
             case "missing tag description" -> MISSING_TAG_DESCRIPTION;
             case "missing datetime description" -> MISSING_DATETIME_DESCRIPTION;
             case "missing task description" -> MISSING_TASK_DESCRIPTION;


### PR DESCRIPTION
The event end date/time can be before the start date/time.

The user need to know when their input time range is valid.

Add an invalid timeline error message and apply the message to event command.

The event start time should be before the end time.